### PR TITLE
Added support for transaction comments #78

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -42,7 +42,11 @@ var settings = {
         // enables custom transactions. If enabled, payment steps are reduced
         // to only 4 steps
         customTransactions: true
+
     },
+
+    // Enable comment section for custom transfers, Requires backend >= 1.6.0
+    comments: false,
 
     /////////////////////////////////////////////////////////////////////////
     // i18n section

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -19,6 +19,7 @@
     "transactionForUser": "Transaktionsübersicht für „{name}”",
     "transactionCurrentPage": "Seite {current}/{max}",
     "transactionCreateDate": "Buchungsdatum",
+    "transactionComment": "Kommentar",
     "transactionValue": "Wert",
     "transactionBoundaryReached": "Die Transaktion hat die Ober- oder Untergrenze überschritten.",
     "nextPage": "Nächste",
@@ -43,5 +44,6 @@
     "customTransactionDescription": "Gib hier deinen Wunschbetrag ein:",
     "customTransactionPay": "Einkauf bezahlen",
     "customTransactionCharge": "Guthaben aufladen",
-    "customTransactionValueTooSmall": "Eine Transaktion kann nicht kleiner als 0.01 {currency} sein."
+    "customTransactionValueTooSmall": "Eine Transaktion kann nicht kleiner als 0.01 {currency} sein.",
+    "customTransactionCommentInputPlaceholder": "Kommentar der Transaktion"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,5 +45,5 @@
     "customTransactionPay": "Pay purchase",
     "customTransactionCharge": "Charge wallet",
     "customTransactionValueTooSmall": "Transaction value can't be smaller than 0.01 {currency}",
-    "customTransactionCommentInputPlaceholder": "Enter a transaction comment"
+    "customTransactionCommentInputPlaceholder": "transaction comment"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,6 +19,7 @@
     "transactionForUser": "Transactions for user „{name}”",
     "transactionCurrentPage": "Page {current}/{max}",
     "transactionCreateDate": "create date",
+    "transactionComment": "comment",
     "transactionValue": "value",
     "transactionBoundaryReached": "The transaction exceeded the upper or lower boundary",
     "nextPage": "Next",
@@ -43,5 +44,6 @@
     "customTransactionDescription": "Enter your custom transaction value here:",
     "customTransactionPay": "Pay purchase",
     "customTransactionCharge": "Charge wallet",
-    "customTransactionValueTooSmall": "Transaction value can't be smaller than 0.01 {currency}"
+    "customTransactionValueTooSmall": "Transaction value can't be smaller than 0.01 {currency}",
+    "customTransactionCommentInputPlaceholder": "Enter a transaction comment"
 }

--- a/src/script/lib/controllers/transaction/transaction.html
+++ b/src/script/lib/controllers/transaction/transaction.html
@@ -22,16 +22,16 @@
             <table class="table table-striped">
                 <thead>
                     <tr>
-                        <th translate>transactionCreateDate</th>
+                        <th translate class="col-xs-1">transactionCreateDate</th>
                         <th translate>transactionComment</th>
-                        <th class="text-right" translate>transactionValue</th>
+                        <th class="text-right col-xs-2" translate>transactionValue</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr ng-repeat="transaction in transactions | orderBy:'-id' track by transaction.id">
-                        <td>{{transaction.createDate | localtime}}</td>
+                        <td class="col-xs-1">{{transaction.createDate | localtime}}</td>
                         <td>{{transaction.comment}}</td>
-                        <td class="balance text-right" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value|number:2}} {{currency}}</td>
+                        <td class="balance text-right col-xs-2" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value|number:2}} {{currency}}</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/script/lib/controllers/transaction/transaction.html
+++ b/src/script/lib/controllers/transaction/transaction.html
@@ -23,12 +23,14 @@
                 <thead>
                     <tr>
                         <th translate>transactionCreateDate</th>
+                        <th translate>transactionComment</th>
                         <th translate>transactionValue</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr ng-repeat="transaction in transactions | orderBy:'-id' track by transaction.id">
                         <td>{{transaction.createDate | localtime}}</td>
+                        <td>{{transaction.comment}}</td>
                         <td class="balance" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value|number:2}} {{currency}}</td>
                     </tr>
                 </tbody>

--- a/src/script/lib/controllers/transaction/transaction.html
+++ b/src/script/lib/controllers/transaction/transaction.html
@@ -24,14 +24,14 @@
                     <tr>
                         <th translate>transactionCreateDate</th>
                         <th translate>transactionComment</th>
-                        <th translate>transactionValue</th>
+                        <th class="text-right" translate>transactionValue</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr ng-repeat="transaction in transactions | orderBy:'-id' track by transaction.id">
                         <td>{{transaction.createDate | localtime}}</td>
                         <td>{{transaction.comment}}</td>
-                        <td class="balance" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value|number:2}} {{currency}}</td>
+                        <td class="balance text-right" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value|number:2}} {{currency}}</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/script/lib/controllers/user/user.html
+++ b/src/script/lib/controllers/user/user.html
@@ -36,6 +36,7 @@
                     <tbody>
                     <tr ng-repeat="transaction in user.transactions | orderBy:'-id' | limitTo : 5">
                         <td>{{transaction.createDate | localtime}}</td>
+                        <td>{{transaction.comment}}</td>
                         <td class="balance" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value | number:2}} {{currency}}</td>
                     </tr>
                     </tbody>

--- a/src/script/lib/controllers/user/user.html
+++ b/src/script/lib/controllers/user/user.html
@@ -35,9 +35,9 @@
                 <table class="table table-striped">
                     <tbody>
                     <tr ng-repeat="transaction in user.transactions | orderBy:'-id' | limitTo : 5">
-                        <td>{{transaction.createDate | localtime}}</td>
+                        <td class="col-xs-2">{{transaction.createDate | localtime}}</td>
                         <td>{{transaction.comment}}</td>
-                        <td class="balance text-right" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value | number:2}} {{currency}}</td>
+                        <td class="balance text-right col-xs-2" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value | number:2}} {{currency}}</td>
                     </tr>
                     </tbody>
                 </table>

--- a/src/script/lib/controllers/user/user.html
+++ b/src/script/lib/controllers/user/user.html
@@ -37,7 +37,7 @@
                     <tr ng-repeat="transaction in user.transactions | orderBy:'-id' | limitTo : 5">
                         <td>{{transaction.createDate | localtime}}</td>
                         <td>{{transaction.comment}}</td>
-                        <td class="balance" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value | number:2}} {{currency}}</td>
+                        <td class="balance text-right" ng-class="transaction.value < 0 ? 'negative' : ''">{{transaction.value | number:2}} {{currency}}</td>
                     </tr>
                     </tbody>
                 </table>

--- a/src/script/lib/controllers/user/user.js
+++ b/src/script/lib/controllers/user/user.js
@@ -69,8 +69,10 @@ angular
                 $scope.transactionRunning = false;
             }, 800);
 
+            var comment = 'Default transaction';
+
             Transaction
-                .createTransaction(userId, value)
+                .createTransaction(userId, value, comment)
                 .success(function() {
                     loadUser(userId);
                 })

--- a/src/script/lib/modals/customTransaction/customTransaction.html
+++ b/src/script/lib/modals/customTransaction/customTransaction.html
@@ -21,8 +21,8 @@
                    placeholder="0.42"
                    ng-model="transactionValue" required autocomplete="off" autofocus>
         </div>
-        <br>
-        <div class="input-group input-group-lg">
+        <br ng-if="enableComments">
+        <div class="input-group input-group-lg" ng-if="enableComments">
             <span class="input-group-addon" translate>transactionComment</span>
             <input type="text"
             class="form-control transaction-comment"

--- a/src/script/lib/modals/customTransaction/customTransaction.html
+++ b/src/script/lib/modals/customTransaction/customTransaction.html
@@ -28,7 +28,7 @@
             class="form-control transaction-comment"
             placeholder="{{'customTransactionCommentInputPlaceholder' | translate}}"
             maxlength="64"
-            ng-model="transactionComment" required autocomplete="off">
+            ng-model="transactionComment" autocomplete="off">
         </div>
     </form>
 </div>

--- a/src/script/lib/modals/customTransaction/customTransaction.html
+++ b/src/script/lib/modals/customTransaction/customTransaction.html
@@ -22,7 +22,8 @@
                    ng-model="transactionValue" required autocomplete="off" autofocus>
         </div>
         <br>
-        <div class="input-group input-group-lg col-xs-12">
+        <div class="input-group input-group-lg">
+            <span class="input-group-addon" translate>transactionComment</span>
             <input type="text"
             class="form-control transaction-comment"
             placeholder="{{'customTransactionCommentInputPlaceholder' | translate}}"

--- a/src/script/lib/modals/customTransaction/customTransaction.html
+++ b/src/script/lib/modals/customTransaction/customTransaction.html
@@ -12,7 +12,7 @@
     </alert>
 
     <p translate>customTransactionDescription</p>
-    <form ng-submit="submitTransaction(transactionValue)">
+    <form ng-submit="submitTransaction(transactionValue, transactionComment)">
         <div class="input-group input-group-lg">
             <span class="input-group-addon">{{currency}}</span>
             <input type="number"
@@ -21,17 +21,25 @@
                    placeholder="0.42"
                    ng-model="transactionValue" required autocomplete="off" autofocus>
         </div>
+        <br>
+        <div class="input-group input-group-lg">
+            <input type="text"
+            class="form-control transaction-comment"
+            placeholder="{{'customTransactionCommentInputPlaceholder' | translate}}"
+            maxlength="64"
+            ng-model="transactionComment" required autocomplete="off">
+        </div>
     </form>
 </div>
 
 <div class="modal-footer">
     <button class="btn btn-lg btn-primary"
             ng-disabled="boundary.exceedsLowerLimit(user.balance - transactionValue)"
-            ng-click="submitTransaction(transactionValue)"
+            ng-click="submitTransaction(transactionValue, transactionComment)"
             ng-if="transactionMode == 'spend'" translate>customTransactionPay</button>
     <button class="btn btn-lg btn-success"
             ng-disabled="boundary.exceedsUpperLimit(user.balance + transactionValue)"
-            ng-click="submitTransaction(transactionValue)"
+            ng-click="submitTransaction(transactionValue, transactionComment)"
             ng-if="transactionMode == 'charge'" translate>customTransactionCharge</button>
     <button class="btn btn-lg btn-default" ng-click="cancel()" translate>cancel</button>
 </div>

--- a/src/script/lib/modals/customTransaction/customTransaction.html
+++ b/src/script/lib/modals/customTransaction/customTransaction.html
@@ -22,7 +22,7 @@
                    ng-model="transactionValue" required autocomplete="off" autofocus>
         </div>
         <br>
-        <div class="input-group input-group-lg">
+        <div class="input-group input-group-lg col-xs-12">
             <input type="text"
             class="form-control transaction-comment"
             placeholder="{{'customTransactionCommentInputPlaceholder' | translate}}"

--- a/src/script/lib/modals/customTransaction/customTransaction.js
+++ b/src/script/lib/modals/customTransaction/customTransaction.js
@@ -35,7 +35,7 @@ angular
                 $scope.boundary = result;
             });
 
-        $scope.submitTransaction = function(value) {
+        $scope.submitTransaction = function(value, comment) {
 
             if(settings.audio.transaction) {
                 Audio.play(settings.audio.transaction);
@@ -55,8 +55,12 @@ angular
                 value *= -1;
             }
 
+            if(!comment) {
+                comment = 'Custom transaction';
+            }
+
             Transaction
-                .createTransaction(userId, value)
+                .createTransaction(userId, value, comment)
                 .success(function() {
                     $modalInstance.close();
                     $route.reload();

--- a/src/script/lib/modals/customTransaction/customTransaction.js
+++ b/src/script/lib/modals/customTransaction/customTransaction.js
@@ -19,6 +19,8 @@ angular
         // Because of some scope issues, we need to initialize the substructure
         $scope.transactionMode = transactionMode;
 
+        $scope.enableComments = settings.comments;
+
         $scope.cancel = function() {
             $modalInstance.close();
         };

--- a/src/script/lib/services/transaction.js
+++ b/src/script/lib/services/transaction.js
@@ -15,9 +15,10 @@ angular
             });
         };
 
-        Transaction.prototype.createTransaction = function(userId, value) {
+        Transaction.prototype.createTransaction = function(userId, value, comment) {
             return $http.post(settings.server + '/user/' + userId + '/transaction', {
-                value: value
+                value: value,
+                comment: comment
             });
         };
 


### PR DESCRIPTION
Features:
* Add optional comment field for custom transaction
* Show comment for transaction overviews
* Fixed: The "show all transactions" 2 (now 3) column table differs in size for the last page (issue existed before this PR already).
* Hitting enter after entering custom transaction values does not work anymore -> This is a browser limitation if >=2 input fields are used. Nothing we can do about this issue

**Translations for other languages have to be updated of course.**

This only works with a new version of the backend of course. See https://github.com/hackerspace-bootstrap/strichliste/pull/273