### PR TITLE
Added option to disable dispense and deposit options

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -35,15 +35,15 @@ var settings = {
 
         // payment steps for wallet charging
         deposit: [0.50, 1.00, 2.00, 5.00, 10.00],
+        enableDeposit: true,
 
         // payment steps for payment
         dispense: [0.50, 1.00, 1.50, 2.00, 0.70],
+        enableDispense: true,
 
         // payment steps for transfer
         transfer: [0.50, 1.00, 2.00, 5.00, 10.00],
-
-        // enable "transfer money to somebody else" option
-        wireTransfer: false,
+        enableTransfer: false,
 
         // enables custom transactions. If enabled, payment steps are reduced
         // to only 4 steps

--- a/src/script/lib/controllers/user/user.html
+++ b/src/script/lib/controllers/user/user.html
@@ -17,13 +17,13 @@
 
             <div class="col-xs-12 col-sm-6 credit">
 
-                <div class="clearfix">
+                <div class="clearfix" ng-if="enableDeposit">
                     <h3 translate>userChargeWallet</h3>
                     <button class="btn btn-success btn-lg col-xs-12 col-sm-2" ng-disabled="transactionRunning || boundary.exceedsUpperLimit(user.balance + step)" ng-click="transactionClick(step)" ng-repeat="step in depositSteps">{{step | number:2}} {{currency}}</button>
                     <button class="btn btn-success btn-lg col-xs-12 col-sm-2" ng-disabled="transactionRunning || boundary.exceedsOrEqualsUpperLimit(user.balance)" ng-click="customTransactionClick('charge')" ng-if="customTransactions">? {{currency}}</button>
                 </div>
 
-                <div class="clearfix">
+                <div class="clearfix" ng-if="enableDispense">
                     <h3 translate>userSpendMoney</h3>
                     <button class="btn btn-primary btn-lg col-xs-12 col-sm-2" ng-disabled="transactionRunning || boundary.exceedsLowerLimit(user.balance - step)" ng-click="transactionClick(step*-1)" ng-repeat="step in dispenseSteps">{{step | number:2}} {{currency}}</button>
                     <button class="btn btn-primary btn-lg col-xs-12 col-sm-2" ng-disabled="transactionRunning || boundary.exceedsOrEqualsLowerLimit(user.balance)" ng-click="customTransactionClick('spend')" ng-if="customTransactions">? {{currency}}</button>

--- a/src/script/lib/controllers/user/user.js
+++ b/src/script/lib/controllers/user/user.js
@@ -23,7 +23,9 @@ angular
 
         var userId = $routeParams.userId;
 
-        $scope.enableTransfer = settings.paymentSteps.wireTransfer;
+        $scope.enableDeposit = settings.paymentSteps.enableDeposit;
+        $scope.enableDispense = settings.paymentSteps.enableDispense;
+        $scope.enableTransfer = settings.paymentSteps.enableTransfer;
 
         function loadUser(userId) {
             User


### PR DESCRIPTION
As the new version now has transfer support it is also useful to disable the dispense and deposit options and only use transfer.

We are planning to use this to transfer money between people with a virtual balance. As for some reason the overall balance was !=0 we decided to just disable normal options and just use the transfer. The wrong balance was possibly caused by a user, not the software itself.